### PR TITLE
Kalshi support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.env
 *.db3
 *.tmp
+.vscode/

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,11 @@
 [database]
 path = "./prod-db.db3"
 
+[kalshi]
+add_group_ids = [
+    "krovXmDn6rCdoiJjbe7R", # Kalshi
+]
+
 [manifold]
 url = "https://manifold.markets/"
 api_key = "SECRET"  # overridden by MB_MANIFOLD.API_KEY env variable
@@ -58,4 +63,3 @@ max_last_active_days = 90
 max_age_days = 36525
 max_confidence = 0.97
 exclude_ids = []
-

--- a/config.toml
+++ b/config.toml
@@ -11,17 +11,17 @@ add_group_ids = [
 require_open = true
 exclude_resolved = true
 exclude_series = true
-min_liquidity = 0
-min_volume = 0
-min_recent_volume = 0
-min_open_interest = 0
+min_liquidity = 20000
+min_volume = 500
+min_recent_volume = 30
+min_open_interest = 30
 min_dollar_volume = 0
 min_dollar_recent_volume = 0
 min_dollar_open_interest = 0
 min_days_to_resolution = 2
-max_days_to_resolution = 4000
+max_days_to_resolution = 365
 max_age_days = 365
-max_confidence = 0.94
+max_confidence = 0.92
 exclude_ids = []
 
 [manifold]

--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,6 @@ add_group_ids = [
 
 [kalshi.auto_filter]
 require_open = true
-page_size = 200
 single_event_per_series = false
 exclude_resolved = true
 exclude_series = true

--- a/config.toml
+++ b/config.toml
@@ -9,9 +9,10 @@ add_group_ids = [
 
 [kalshi.auto_filter]
 require_open = true
+page_size = 200
+single_event_per_series = false
 exclude_resolved = true
 exclude_series = true
-single_event_per_series = false
 min_liquidity = 20000
 min_volume = 500
 min_recent_volume = 30

--- a/config.toml
+++ b/config.toml
@@ -2,9 +2,27 @@
 path = "./prod-db.db3"
 
 [kalshi]
+max_clones_per_day = 1
 add_group_ids = [
     "krovXmDn6rCdoiJjbe7R", # Kalshi
 ]
+
+[kalshi.auto_filter]
+require_open = true
+exclude_resolved = true
+exclude_series = true
+min_liquidity = 0
+min_volume = 0
+min_recent_volume = 0
+min_open_interest = 0
+min_dollar_volume = 0
+min_dollar_recent_volume = 0
+min_dollar_open_interest = 0
+min_days_to_resolution = 2
+max_days_to_resolution = 4000
+max_age_days = 365
+max_confidence = 0.94
+exclude_ids = []
 
 [manifold]
 url = "https://manifold.markets/"

--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,7 @@ add_group_ids = [
 require_open = true
 exclude_resolved = true
 exclude_series = true
+single_event_per_series = false
 min_liquidity = 20000
 min_volume = 500
 min_recent_volume = 30

--- a/dev-config.toml
+++ b/dev-config.toml
@@ -8,20 +8,6 @@ add_group_ids = [
 ]
 
 [kalshi.auto_filter]
-require_open = true
-exclude_resolved = true
-exclude_series = true
-min_liquidity = 0
-min_volume = 0
-min_recent_volume = 0
-min_open_interest = 0
-min_dollar_volume = 0
-min_dollar_recent_volume = 0
-min_dollar_open_interest = 0
-min_days_to_resolution = 2
-max_days_to_resolution = 4000
-max_age_days = 365
-max_confidence = 0.94
 exclude_ids = []
 
 [manifold]

--- a/dev-config.toml
+++ b/dev-config.toml
@@ -1,6 +1,11 @@
 [database]
 path = "./dev-db.db3"
 
+[kalshi]
+add_group_ids = [
+    "c7fb5859-6c37-4b10-be04-db8f218d80af", # Kalshi on dev
+]
+
 [manifold]
 url = "https://dev.manifold.markets/"
 user_id = "Lx20DndIKqYBDrAdJz5geUeZnRz1"  # mirrorbot on dev

--- a/dev-config.toml
+++ b/dev-config.toml
@@ -2,9 +2,27 @@
 path = "./dev-db.db3"
 
 [kalshi]
+max_clones_per_day = 1
 add_group_ids = [
     "c7fb5859-6c37-4b10-be04-db8f218d80af", # Kalshi on dev
 ]
+
+[kalshi.auto_filter]
+require_open = true
+exclude_resolved = true
+exclude_series = true
+min_liquidity = 0
+min_volume = 0
+min_recent_volume = 0
+min_open_interest = 0
+min_dollar_volume = 0
+min_dollar_recent_volume = 0
+min_dollar_open_interest = 0
+min_days_to_resolution = 2
+max_days_to_resolution = 4000
+max_age_days = 365
+max_confidence = 0.94
+exclude_ids = []
 
 [manifold]
 url = "https://dev.manifold.markets/"

--- a/src/args.rs
+++ b/src/args.rs
@@ -39,6 +39,9 @@ pub enum Commands {
     /// Sync source resolutions to Manifold
     #[command()]
     Sync {
+        /// Sync Kalshi resolutions to manifold
+        #[arg(short = 'k', long = "kalshi")]
+        kalshi: bool,
         /// Sync Metaculus resolutions to manifold
         #[arg(short = 'm', long = "metaculus")]
         metaculus: bool,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,7 +6,7 @@ use crate::args::{self, Commands, ListCommands};
 use crate::manifold::{self, SendManagramArgs};
 use crate::settings::Settings;
 use crate::types::QuestionSource;
-use crate::{db, log_if_err, kalshi, managrams, metaculus, mirror};
+use crate::{db, kalshi, log_if_err, managrams, metaculus, mirror};
 
 pub(crate) fn run_command(
     config: Settings,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -20,6 +20,7 @@ pub(crate) fn run_command(
             allow_resolved,
         } => mirror_question(&config, source, id, allow_resolved),
         Commands::Sync {
+            kalshi,
             metaculus,
             managrams,
             manifold_self,
@@ -27,6 +28,7 @@ pub(crate) fn run_command(
             all,
         } => sync(
             &config,
+            kalshi,
             metaculus,
             managrams,
             manifold_self,
@@ -124,13 +126,14 @@ pub fn mirror_question(
 
 pub fn sync(
     config: &Settings,
+    kalshi: bool,
     metaculus: bool,
     managrams: bool,
     manifold_self: bool,
     manifold_other: bool,
     all: bool,
 ) -> Result<()> {
-    if !(metaculus || managrams || manifold_self || manifold_other || all) {
+    if !(kalshi || metaculus || managrams || manifold_self || manifold_other || all) {
         bail!("Provide at least one sync target.");
     }
 
@@ -143,6 +146,15 @@ pub fn sync(
 
     if manifold_other || all {
         log_if_err!(mirror::sync_third_party_mirrors(&client, &db, config));
+    }
+
+    if kalshi || all {
+        log_if_err!(mirror::sync_resolutions_to_manifold(
+            &client,
+            &db,
+            config,
+            Some(QuestionSource::Kalshi)
+        ));
     }
 
     if metaculus || all {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,7 +6,7 @@ use crate::args::{self, Commands, ListCommands};
 use crate::manifold::{self, SendManagramArgs};
 use crate::settings::Settings;
 use crate::types::QuestionSource;
-use crate::{db, log_if_err, managrams, metaculus, mirror};
+use crate::{db, log_if_err, kalshi, managrams, metaculus, mirror};
 
 pub(crate) fn run_command(
     config: Settings,
@@ -100,7 +100,21 @@ pub fn mirror_question(
             println!("Mirrored question:\n{:#?}", row);
         }
         QuestionSource::Kalshi => {
-            bail!("Kalshi mirroring hasn't been implemented yet");
+            let kalshi_question = kalshi::get_question(&client, &id, config)
+                .with_context(|| "failed to fetch question from Kalshi")?;
+            if kalshi_question.is_resolved() {
+                if allow_resolved {
+                    warn!("question has already resolved");
+                } else {
+                    return Err(anyhow!("question has already resolved"));
+                }
+            }
+            // let question = (&kalshi_question)
+            //     .try_into()
+            //     .with_context(|| "failed to convert Kalshi question to common format")?;
+            // let row = mirror::mirror_question(&client, &db, &question, config)?;
+            // println!("Mirrored question:\n{:#?}", row);
+            println!("So far so good!");
         }
         QuestionSource::Polymarket => {
             bail!("Polymarket mirroring hasn't been implemented yet");

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -109,11 +109,11 @@ pub fn mirror_question(
                     return Err(anyhow!("question has already resolved"));
                 }
             }
-            // let question = (&kalshi_question)
-            //     .try_into()
-            //     .with_context(|| "failed to convert Kalshi question to common format")?;
-            // let row = mirror::mirror_question(&client, &db, &question, config)?;
-            // println!("Mirrored question:\n{:#?}", row);
+            let question = (&kalshi_question)
+                .try_into()
+                .with_context(|| "failed to convert Kalshi question to common format")?;
+            let row = mirror::mirror_question(&client, &db, &question, config)?;
+            println!("Mirrored question:\n{:#?}", row);
             println!("So far so good!");
         }
         QuestionSource::Polymarket => {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -114,7 +114,6 @@ pub fn mirror_question(
                 .with_context(|| "failed to convert Kalshi question to common format")?;
             let row = mirror::mirror_question(&client, &db, &question, config)?;
             println!("Mirrored question:\n{:#?}", row);
-            println!("So far so good!");
         }
         QuestionSource::Polymarket => {
             bail!("Polymarket mirroring hasn't been implemented yet");
@@ -167,9 +166,7 @@ pub fn auto_mirror(config: &Settings, source: QuestionSource, dry_run: bool) -> 
     let db = db::open(&config)?;
     match source {
         QuestionSource::Metaculus => mirror::auto_mirror_metaculus(&client, &db, config, dry_run)?,
-        QuestionSource::Kalshi => {
-            todo!()
-        }
+        QuestionSource::Kalshi => mirror::auto_mirror_kalshi(&client, &db, config, dry_run)?,
         QuestionSource::Polymarket => {
             todo!()
         }

--- a/src/kalshi.rs
+++ b/src/kalshi.rs
@@ -1,19 +1,25 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use chrono::{DateTime, Duration, Utc};
-use log::{debug, info, warn};
-use reqwest::{
-    blocking::{Client, RequestBuilder},
-    header::AUTHORIZATION,
-};
+use log::{debug, info};
+use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
-use serde_json::value::Value as JsonValue;
 use thiserror::Error;
 
-use crate::settings::Settings;
-// use crate::settings::{KalshiQuestionRequirements, Settings};
-use crate::types::{BinaryResolution, Question, QuestionSource};
+use crate::settings::{KalshiQuestionRequirements, Settings};
+use crate::types::{Question, QuestionSource};
 
-pub fn get_question(client: &Client, id: &str, config: &Settings) -> Result<KalshiQuestion> {
+fn list_questions(
+    client: &Client,
+    params: KalshiListQuestionsParams,
+) -> Result<KalshiQuestionsResponse> {
+    debug!("kalshi::list_questions called"); // (params: {:?})", params);
+    Ok(client.get("https://trading-api.kalshi.com/v1/events/")
+    .query(&params)
+    .send()?
+    .json()?)
+}
+
+pub fn get_question(client: &Client, id: &str, _config: &Settings) -> Result<KalshiQuestion> {
     // The Kalshi api requires the id (ticker) to be uppercase. Their frontend
     // uses lowercase by default, but redirects given uppercase. Use
     // uppercase to be safe.
@@ -26,7 +32,142 @@ pub fn get_question(client: &Client, id: &str, config: &Settings) -> Result<Kals
     Ok(question)
 }
 
+pub fn get_mirror_candidates(client: &Client, config: &Settings) -> Result<Vec<KalshiQuestion>> {
+    info!("Fetching mirror candidates from Kalshi");
+    let requirements = &config.kalshi.auto_filter;
+    let mut params = KalshiListQuestionsParams {
+        single_event_per_series: Some(true),
+        ..Default::default()
+    };
+    if requirements.require_open {
+        params.status = Some("open".to_string()); // TODO: use enum?
+    }
+    let questions = list_questions(client, params)
+        .with_context(|| "failed to fetch questions from kalshi")?
+        .events
+        .into_iter()
+        .map(|event| KalshiQuestion {
+            id: event.ticker.clone(),
+            event,
+        })
+        .filter(|q| check_event_requirements(q, requirements).is_ok())
+        .collect();
+    Ok(questions)
+}
+
+pub fn check_event_requirements(
+    question: &KalshiQuestion,
+    requirements: &KalshiQuestionRequirements,
+) -> Result<(), KalshiCheckFailure> {
+    if ! question.has_matching_market() {
+        return Err(KalshiCheckFailure::NoMatchingMarket);
+    }
+    // config requirements
+    if requirements.exclude_series && question.is_series() {
+        return Err(KalshiCheckFailure::Series);
+    }
+    if requirements.require_open && !question.is_active() {
+        return Err(KalshiCheckFailure::NotActive);
+    }
+    if requirements.exclude_resolved && question.is_resolved() {
+        return Err(KalshiCheckFailure::Resolved);
+    }
+    // Min liquidity
+    if question.get_market().liquidity < requirements.min_liquidity {
+        return Err(KalshiCheckFailure::NotEnoughLiquidity {
+            liquidity: question.get_market().liquidity,
+            threshold: requirements.min_liquidity,
+        });
+    }
+    // Min volume
+    if question.get_market().volume < requirements.min_volume {
+        return Err(KalshiCheckFailure::NotEnoughVolume {
+            volume: question.get_market().volume,
+            threshold: requirements.min_volume,
+        });
+    }
+    // Min recent volume
+    if question.get_market().recent_volume < requirements.min_recent_volume {
+        return Err(KalshiCheckFailure::NotEnoughRecentVolume {
+            recent_volume: question.get_market().recent_volume,
+            threshold: requirements.min_recent_volume,
+        });
+    }
+    // Min open interest
+    if question.get_market().open_interest < requirements.min_open_interest {
+        return Err(KalshiCheckFailure::NotEnoughOpenInterest {
+            open_interest: question.get_market().open_interest,
+            threshold: requirements.min_open_interest,
+        });
+    }
+    // min dollar volume
+    if question.get_market().dollar_volume < requirements.min_dollar_volume {
+        return Err(KalshiCheckFailure::NotEnoughDollarVolume {
+            dollar_volume: question.get_market().dollar_volume,
+            threshold: requirements.min_dollar_volume,
+        });
+    }
+    // min dollar recent volume
+    if question.get_market().dollar_recent_volume < requirements.min_dollar_recent_volume {
+        return Err(KalshiCheckFailure::NotEnoughDollarRecentVolume {
+            dollar_recent_volume: question.get_market().dollar_recent_volume,
+            threshold: requirements.min_dollar_recent_volume,
+        });
+    }
+    // min dollar open interest
+    if question.get_market().dollar_open_interest < requirements.min_dollar_open_interest {
+        return Err(KalshiCheckFailure::NotEnoughDollarOpenInterest {
+            dollar_open_interest: question.get_market().dollar_open_interest,
+            threshold: requirements.min_dollar_open_interest,
+        });
+    }
+
+    if question.time_to_resolution() < Duration::days(requirements.min_days_to_resolution) {
+        return Err(KalshiCheckFailure::ResolvesTooSoon {
+            days_remaining: question.time_to_resolution().num_days(),
+            threshold: requirements.min_days_to_resolution,
+        });
+    }
+    if question.time_to_resolution() > Duration::days(requirements.max_days_to_resolution) {
+        return Err(KalshiCheckFailure::ResolvesTooLate {
+            days_remaining: question.time_to_resolution().num_days(),
+            threshold: requirements.max_days_to_resolution,
+        });
+    }
+    if question.age() > Duration::days(requirements.max_age_days) {
+        return Err(KalshiCheckFailure::TooOld {
+            age_days: question.age().num_days(),
+            threshold: requirements.max_age_days,
+        });
+    }
+    if (100 - question.get_market().yes_ask) > requirements.max_confidence * 100
+    || question.get_market().yes_bid > requirements.max_confidence * 100 {
+        return Err(KalshiCheckFailure::TooExtreme {
+            yes_ask: question.get_market().yes_ask,
+            yes_bid: question.get_market().yes_bid,
+            threshold: requirements.max_confidence,
+        });
+    }
+    if requirements.exclude_ids.contains(&question.id) {
+        return Err(KalshiCheckFailure::Banned);
+    }
+
+    Ok(())
+}
+
 impl KalshiQuestion {
+    pub fn age(&self) -> Duration {
+        Utc::now() - self.get_market().open_date
+    }
+
+    pub fn has_matching_market(&self) -> bool {
+        self.event
+            .markets
+            .iter()
+            .find(|market| market.ticker_name == self.id)
+            .is_some()
+    }
+
     pub fn get_market(&self) -> &Market {
         self.event
             .markets
@@ -40,9 +181,25 @@ impl KalshiQuestion {
         self.get_market().status == Status::Finalized
     }
 
+    pub fn is_active(&self) -> bool {
+        self.get_market().status == Status::Active
+    }
+
+    pub fn is_series(&self) -> bool {
+        self.event.markets.len() > 1
+    }
+
+    pub fn time_to_resolution(&self) -> Duration {
+        self.get_market().expiration_date - Utc::now()
+    }
+
     pub fn full_url(&self) -> String {
         // TODO: grab base from config (consistent with manifold)?
         format!("https://kalshi.com/markets/{}", self.event.series_ticker)
+    }
+
+    pub fn title(&self) -> String {
+        self.get_market().title.clone()
     }
 
     pub fn get_criteria_and_sources(&self) -> String {
@@ -80,6 +237,10 @@ impl TryInto<Question> for &KalshiQuestion {
     }
 }
 
+#[derive(Deserialize, Debug, Clone)]
+pub struct KalshiQuestionsResponse {
+    pub events: Vec<Event>,
+}
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct KalshiQuestion {
@@ -92,6 +253,7 @@ pub struct KalshiQuestion {
 #[serde(rename_all = "snake_case")]
 pub struct Event {
     pub series_ticker: String,
+    pub ticker: String,
     pub markets: Vec<Market>,
     pub settlement_sources: Vec<SettlementSource>,
     pub underlying: String,
@@ -105,15 +267,21 @@ pub struct SettlementSource {
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Market {
+    pub title: String,
     pub ticker_name: String,
     pub status: Status,
+    pub open_date: DateTime<Utc>,
     pub result: Option<KalshiResult>,
     pub yes_bid: i64,
     pub yes_ask: i64,
-    /// The expiration date in format "2024-01-31T15:00:00Z"
-    pub expiration_date: DateTime<Utc>,
-    pub close_date: DateTime<Utc>,
-    pub title: String,
+    pub expiration_date: DateTime<Utc>, // Unsure if we should use close_date, which is earlier
+    pub volume: i64,
+    pub recent_volume: i64,
+    pub open_interest: i64,
+    pub dollar_volume: i64,
+    pub dollar_recent_volume: i64,
+    pub dollar_open_interest: i64,
+    pub liquidity: i64,
 }
 
 
@@ -123,7 +291,7 @@ pub enum Status {
     //todo all options
     Active,
     Closed,
-    Finalized,
+    Finalized, // In GET parameters, use status=settled instead, even though "settled" never shows up in the json response
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
@@ -134,4 +302,46 @@ pub enum KalshiResult {
     No,
     #[serde(rename = "")]
     None,
+}
+
+#[derive(Serialize, Debug, Default)]
+pub struct KalshiListQuestionsParams {
+    pub status: Option<String>,
+    pub single_event_per_series: Option<bool>,
+}
+
+#[derive(Error, Debug)]
+pub enum KalshiCheckFailure {
+    #[error("question does not have matching market id")]
+    NoMatchingMarket,
+    #[error("question is not active")]
+    NotActive,
+    #[error("question is part of a group")]
+    Series,
+    #[error("question has {volume} volume, and the minimum is {threshold}")]
+    NotEnoughVolume { volume: i64, threshold: i64 },
+    #[error("question has {recent_volume} recent_volume, and the minimum is {threshold}")]
+    NotEnoughRecentVolume { recent_volume: i64, threshold: i64 },
+    #[error("question has {open_interest} open_interest, and the minimum is {threshold}")]
+    NotEnoughOpenInterest { open_interest: i64, threshold: i64 },
+    #[error("question has {liquidity} liquidity, and the minimum is {threshold}")]
+    NotEnoughLiquidity { liquidity: i64, threshold: i64 },
+    #[error("question has {dollar_volume} dollar_volume, and the minimum is {threshold}")]
+    NotEnoughDollarVolume { dollar_volume: i64, threshold: i64 },
+    #[error("question has {dollar_recent_volume} dollar_recent_volume, and the minimum is {threshold}")]
+    NotEnoughDollarRecentVolume { dollar_recent_volume: i64, threshold: i64 },
+    #[error("question has {dollar_open_interest} dollar_open_interest, and the minimum is {threshold}")]
+    NotEnoughDollarOpenInterest { dollar_open_interest: i64, threshold: i64 },
+    #[error("question resolves in {days_remaining} days, and the minimum is {threshold}")]
+    ResolvesTooSoon { days_remaining: i64, threshold: i64 },
+    #[error("question resolves in {days_remaining} days, and the maximum is {threshold}")]
+    ResolvesTooLate { days_remaining: i64, threshold: i64 },
+    #[error("question opened {age_days} days ago, and the maximum is {threshold}")]
+    TooOld { age_days: i64, threshold: i64 },
+    #[error("The orderbook has bids at {yes_bid}, asks at {yes_ask}, and the maximum confidence is {threshold}")]
+    TooExtreme { yes_bid: i64, yes_ask: i64, threshold: i64 },
+    #[error("question has already resolved")]
+    Resolved,
+    #[error("question is banned in config")]
+    Banned,
 }

--- a/src/kalshi.rs
+++ b/src/kalshi.rs
@@ -1,0 +1,71 @@
+use anyhow::{anyhow, Context, Result};
+use chrono::{DateTime, Duration, Utc};
+use log::{debug, info, warn};
+use reqwest::{
+    blocking::{Client, RequestBuilder},
+    header::AUTHORIZATION,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::value::Value as JsonValue;
+use thiserror::Error;
+
+use crate::settings::Settings;
+// use crate::settings::{KalshiQuestionRequirements, Settings};
+use crate::types::{BinaryResolution, Question, QuestionSource};
+
+pub fn get_question(client: &Client, id: &str, config: &Settings) -> Result<KalshiQuestion> {
+    debug!("get_question called (id: {})", id);
+    Ok(client.get(format!("https://trading-api.kalshi.com/v1/events/{}/", id))
+    .send()?
+    .json()?)
+}
+
+impl KalshiQuestion {
+    pub fn is_resolved(&self) -> bool {
+        // todo filter for market that has the ticker_name we gave as an argument
+        self.event.markets[0].status == Status::Finalized
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct KalshiQuestion {
+    pub event: Event,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct Event {
+    pub markets: Vec<Market>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct Market {
+    pub status: Status,
+    pub result: Option<KalshiResult>,
+    pub yes_bid: i64,
+    pub yes_ask: i64,
+    /// The expiration date in format "2024-01-31T15:00:00Z"
+    pub expiration_date: String,
+    pub close_date: String,
+    pub title: String,
+}
+
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum Status {
+    //todo all options
+    Active,
+    Closed,
+    Finalized,
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum KalshiResult {
+    //todo all options
+    Yes,
+    No,
+    #[serde(rename = "")]
+    None,
+}

--- a/src/kalshi.rs
+++ b/src/kalshi.rs
@@ -40,16 +40,16 @@ pub fn get_mirror_candidates(client: &Client, config: &Settings) -> Result<Vec<K
     info!("Fetching mirror candidates from Kalshi");
     let requirements = &config.kalshi.auto_filter;
     let mut params = KalshiListQuestionsParams {
+        single_event_per_series: Some(requirements.single_event_per_series),
+        page_size: Some(200),
+        page_number: Some(1),
         ..Default::default()
     };
     if requirements.require_open {
         params.status = Some("open".to_string()); // TODO: use enum?
     }
-    params.single_event_per_series = Some(requirements.single_event_per_series);
-    params.page_size = Some(requirements.page_size);
     let mut events = Vec::new();
     for page_number in 1..100 {
-        // Set page_number in params
         params.page_number = Some(page_number);
         let resp = list_questions(client, &params)?;
         // single_event_per_series, and perhaps other filtering parameters, are

--- a/src/kalshi.rs
+++ b/src/kalshi.rs
@@ -167,9 +167,8 @@ pub fn check_event_requirements(
         return Err(KalshiCheckFailure::Banned);
     }
 
-    println!("Passed all Kalshi checks URL: {} ({}), liq {}, bid/ask {}/{}, volume {} (${}), recent volume {} (${}), open interest {} (${})",
+    println!("Passed all Kalshi checks URL: {}, liq {}, bid/ask {}/{}, volume {} (${}), recent volume {} (${}), open interest {} (${})",
         question.full_url(),
-        question.id,
         question.get_market().liquidity,
         question.get_market().yes_bid,
         question.get_market().yes_ask,
@@ -241,7 +240,7 @@ impl KalshiQuestion {
 
     pub fn full_url(&self) -> String {
         // TODO: grab base from config (consistent with manifold)?
-        format!("https://kalshi.com/markets/{}", self.event.series_ticker)
+        format!("https://kalshi.com/markets/{}#{}", self.event.series_ticker, self.id)
     }
 
     pub fn title(&self) -> String {

--- a/src/kalshi.rs
+++ b/src/kalshi.rs
@@ -15,38 +15,74 @@ use crate::types::{BinaryResolution, Question, QuestionSource};
 
 pub fn get_question(client: &Client, id: &str, config: &Settings) -> Result<KalshiQuestion> {
     debug!("get_question called (id: {})", id);
-    Ok(client.get(format!("https://trading-api.kalshi.com/v1/events/{}/", id))
-    .send()?
-    .json()?)
+    let mut question = client.get(format!("https://trading-api.kalshi.com/v1/events/{}/", id))
+        .send()?
+        .json::<KalshiQuestion>()?;
+    question.id = id.to_string();
+    Ok(question)
 }
 
 impl KalshiQuestion {
+    pub fn get_market(&self) -> &Market {
+        self.event
+            .markets
+            .iter()
+            .find(|market| market.ticker_name == self.id)
+            .unwrap()
+    }
+
     pub fn is_resolved(&self) -> bool {
-        // todo filter for market that has the ticker_name we gave as an argument
-        self.event.markets[0].status == Status::Finalized
+        self.get_market().status == Status::Finalized
+    }
+
+    pub fn full_url(&self) -> String {
+        // TODO: grab base from config (consistent with manifold)?
+        // Don't think there even is a public dev instance though.
+        format!("https://kalshi.com/markets/{}", self.event.series_ticker)
     }
 }
+
+impl TryInto<Question> for &KalshiQuestion {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> Result<Question> {
+        Ok(Question {
+            source: QuestionSource::Kalshi,
+            source_url: self.full_url(),
+            source_id: self.id.clone(),
+            question: self.get_market().title.clone(),
+            criteria: Some(self.event.underlying.clone()),
+            end_date: self.get_market().expiration_date,
+        })
+    }
+}
+
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct KalshiQuestion {
     pub event: Event,
+    #[serde(skip)]
+    pub id: String,
 }
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct Event {
+    pub series_ticker: String,
     pub markets: Vec<Market>,
+    pub underlying: String,
 }
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Market {
+    pub ticker_name: String,
     pub status: Status,
     pub result: Option<KalshiResult>,
     pub yes_bid: i64,
     pub yes_ask: i64,
     /// The expiration date in format "2024-01-31T15:00:00Z"
-    pub expiration_date: String,
-    pub close_date: String,
+    pub expiration_date: DateTime<Utc>,
+    pub close_date: DateTime<Utc>,
     pub title: String,
 }
 

--- a/src/kalshi.rs
+++ b/src/kalshi.rs
@@ -36,12 +36,12 @@ pub fn get_mirror_candidates(client: &Client, config: &Settings) -> Result<Vec<K
     info!("Fetching mirror candidates from Kalshi");
     let requirements = &config.kalshi.auto_filter;
     let mut params = KalshiListQuestionsParams {
-        single_event_per_series: Some(true),
         ..Default::default()
     };
     if requirements.require_open {
         params.status = Some("open".to_string()); // TODO: use enum?
     }
+    params.single_event_per_series = Some(requirements.single_event_per_series);
     let questions = list_questions(client, params)
         .with_context(|| "failed to fetch questions from kalshi")?
         .events

--- a/src/kalshi.rs
+++ b/src/kalshi.rs
@@ -203,7 +203,25 @@ impl KalshiQuestion {
     }
 
     pub fn get_criteria_and_sources(&self) -> String {
-        format!("{}{}", self.event.underlying, self.get_resolution_sources_markdown())
+        format!("{}{}", self.format_underlying_rulebook_variables(), self.get_resolution_sources_markdown())
+    }
+
+    pub fn format_underlying_rulebook_variables(&self) -> String {
+        let mut return_string = self.event.underlying.clone();
+        // For each variable in market.rulebook_variables, substitute ||variable|| with the value of the variable
+        let rulebook = self.get_market().rulebook_variables.clone();
+        // For each key in rulebook
+        for key in rulebook.as_object().unwrap().keys() {
+            // Remove the surrounding "" marks
+            let mut replacement_value = rulebook[key].to_string();
+            replacement_value = replacement_value[1..replacement_value.len()-1].to_string();
+
+            // We've seen instances with and without spaces
+            return_string = return_string.replace(&format!("||{}||", key), &replacement_value);
+            return_string = return_string.replace(&format!("|| {} ||", key), &replacement_value);
+        }
+        return return_string
+
     }
 
     pub fn get_resolution_sources_markdown(&self) -> String {
@@ -282,6 +300,7 @@ pub struct Market {
     pub dollar_recent_volume: i64,
     pub dollar_open_interest: i64,
     pub liquidity: i64,
+    pub rulebook_variables: serde_json::Value,
 }
 
 

--- a/src/kalshi.rs
+++ b/src/kalshi.rs
@@ -139,8 +139,8 @@ pub fn check_event_requirements(
             threshold: requirements.max_age_days,
         });
     }
-    if (100 - question.get_market().yes_ask) > requirements.max_confidence * 100
-    || question.get_market().yes_bid > requirements.max_confidence * 100 {
+    if (100 - question.get_market().yes_ask) as f64 > requirements.max_confidence * 100.0
+    || question.get_market().yes_bid as f64 > requirements.max_confidence * 100.0 {
         return Err(KalshiCheckFailure::TooExtreme {
             yes_ask: question.get_market().yes_ask,
             yes_bid: question.get_market().yes_bid,
@@ -150,6 +150,20 @@ pub fn check_event_requirements(
     if requirements.exclude_ids.contains(&question.id) {
         return Err(KalshiCheckFailure::Banned);
     }
+
+    println!("Passed all Kalshi checks URL: {}, liq {}, bid/ask {}/{}, volume {} (${}), recent volume {} (${}), open interest {} (${})",
+        question.full_url(),
+        question.get_market().liquidity,
+        question.get_market().yes_bid,
+        question.get_market().yes_ask,
+        question.get_market().volume,
+        question.get_market().dollar_volume,
+        question.get_market().recent_volume,
+        question.get_market().dollar_recent_volume,
+        question.get_market().open_interest,
+        question.get_market().dollar_open_interest
+    );
+    return Err(KalshiCheckFailure::Banned);
 
     Ok(())
 }
@@ -369,7 +383,7 @@ pub enum KalshiCheckFailure {
     #[error("question opened {age_days} days ago, and the maximum is {threshold}")]
     TooOld { age_days: i64, threshold: i64 },
     #[error("The orderbook has bids at {yes_bid}, asks at {yes_ask}, and the maximum confidence is {threshold}")]
-    TooExtreme { yes_bid: i64, yes_ask: i64, threshold: i64 },
+    TooExtreme { yes_bid: i64, yes_ask: i64, threshold: f64 },
     #[error("question has already resolved")]
     Resolved,
     #[error("question is banned in config")]

--- a/src/kalshi.rs
+++ b/src/kalshi.rs
@@ -14,6 +14,10 @@ use crate::settings::Settings;
 use crate::types::{BinaryResolution, Question, QuestionSource};
 
 pub fn get_question(client: &Client, id: &str, config: &Settings) -> Result<KalshiQuestion> {
+    // The Kalshi api requires the id (ticker) to be uppercase. Their frontend
+    // uses lowercase by default, but redirects given uppercase. Use
+    // uppercase to be safe.
+    let id = id.to_uppercase();
     debug!("get_question called (id: {})", id);
     let mut question = client.get(format!("https://trading-api.kalshi.com/v1/events/{}/", id))
         .send()?
@@ -28,6 +32,7 @@ impl KalshiQuestion {
             .markets
             .iter()
             .find(|market| market.ticker_name == self.id)
+            .with_context(|| format!("Could not find market in series {} with ticker_name {}", self.id, self.id))
             .unwrap()
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 mod args;
 mod commands;
 mod db;
+mod kalshi;
 mod managrams;
 mod manifold;
 mod metaculus;

--- a/src/manifold.rs
+++ b/src/manifold.rs
@@ -487,7 +487,7 @@ impl CreateMarketArgs {
                 group_ids.extend(config.metaculus.add_group_ids.iter().cloned())
             }
             QuestionSource::Kalshi => {
-                todo!()
+                group_ids.extend(config.kalshi.add_group_ids.iter().cloned())
             }
             QuestionSource::Polymarket => {
                 todo!()

--- a/src/manifold.rs
+++ b/src/manifold.rs
@@ -486,9 +486,7 @@ impl CreateMarketArgs {
             QuestionSource::Metaculus => {
                 group_ids.extend(config.metaculus.add_group_ids.iter().cloned())
             }
-            QuestionSource::Kalshi => {
-                group_ids.extend(config.kalshi.add_group_ids.iter().cloned())
-            }
+            QuestionSource::Kalshi => group_ids.extend(config.kalshi.add_group_ids.iter().cloned()),
             QuestionSource::Polymarket => {
                 todo!()
             }

--- a/src/metaculus.rs
+++ b/src/metaculus.rs
@@ -384,7 +384,7 @@ impl MetaculusQuestion {
             if self.possibilities.r#type == ForecastType::Binary {
                 match self.resolution {
                     Some(-2.0) => {
-                        // Anulled
+                        // Annulled
                         Ok(Some(BinaryResolution::Cancel))
                     }
                     Some(-1.0) => {

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -21,6 +21,8 @@ pub enum MirrorError {
     #[error("Question has already been mirrored at {}", .0.manifold_url)]
     AlreadyMirrored(MirrorRow),
     #[error(transparent)]
+    KalshiError(#[from] kalshi::KalshiError),
+    #[error(transparent)]
     ManifoldError(#[from] manifold::ManifoldError),
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -13,6 +13,11 @@ pub struct Database {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct Kalshi {
+    pub add_group_ids: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct MarketTemplate {
     pub description_footer: String,
     pub title_retain_end_characters: usize,
@@ -69,6 +74,7 @@ pub struct Metaculus {
 #[derive(Debug, Deserialize)]
 pub struct Settings {
     pub database: Database,
+    pub kalshi: Kalshi,
     pub manifold: Manifold,
     pub metaculus: Metaculus,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -28,10 +28,15 @@ pub struct KalshiQuestionRequirements {
     /// markets for e.g. different price points of an asset.) For the most
     /// part, only one event of a series is open at once, and in those cases
     /// this parameter changes nothing.
-    /// One example where there are multiple open markets is TERMINALRATE,
-    /// seen here: https://kalshi.com/markets/TERMINALRATE. In these cases,
+    ///
+    /// One example where there are multiple open markets is RATECUT,
+    /// seen here: https://kalshi.com/markets/RATECUT. In these cases,
     /// single_event_per_series appears to return the event/markets that
-    /// appear by default on the frontend. (TERMINALRATE-23DEC31B)
+    /// appear by default on the frontend. (RATECUT-23DEC31)
+    ///
+    /// I think false is a sensible default. At time of writing in the RATECUT
+    /// case, the 2023 version is probably NO, but it has 2024 versions that
+    /// are still up in the air and getting attention from traders.
     pub single_event_per_series: bool,
     pub exclude_resolved: bool,
     pub exclude_series: bool,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -22,6 +22,16 @@ pub struct Kalshi {
 #[derive(Debug, Deserialize)]
 pub struct KalshiQuestionRequirements {
     pub require_open: bool,
+    /// There are some events that use the same series ticker to group
+    /// events. (Not to be confused with each event containing multiple
+    /// markets for e.g. different price points of an asset.) For the most
+    /// part, only one event of a series is open at once, and in those cases
+    /// this parameter changes nothing.
+    /// One example where there are multiple open markets is TERMINALRATE,
+    /// seen here: https://kalshi.com/markets/TERMINALRATE. In these cases,
+    /// single_event_per_series appears to return the event/markets that
+    /// appear by default on the frontend. (TERMINALRATE-23DEC31B)
+    pub single_event_per_series: bool,
     pub exclude_resolved: bool,
     pub exclude_series: bool,
     pub min_days_to_resolution: i64,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -35,7 +35,7 @@ pub struct KalshiQuestionRequirements {
     pub min_liquidity: i64,
     pub max_age_days: i64,
     /// exclude question if community forecast puts a high probability on YES or NO
-    pub max_confidence: i64,
+    pub max_confidence: f64,
     pub exclude_ids: HashSet<String>,
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -22,7 +22,6 @@ pub struct Kalshi {
 #[derive(Debug, Deserialize)]
 pub struct KalshiQuestionRequirements {
     pub require_open: bool,
-    pub page_size: i64,
     /// There are some events that use the same series ticker to group
     /// events. (Not to be confused with each event containing multiple
     /// markets for e.g. different price points of an asset.) For the most

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -14,7 +14,29 @@ pub struct Database {
 
 #[derive(Debug, Deserialize)]
 pub struct Kalshi {
+    pub auto_filter: KalshiQuestionRequirements,
     pub add_group_ids: Vec<String>,
+    pub max_clones_per_day: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct KalshiQuestionRequirements {
+    pub require_open: bool,
+    pub exclude_resolved: bool,
+    pub exclude_series: bool,
+    pub min_days_to_resolution: i64,
+    pub max_days_to_resolution: i64,
+    pub min_volume: i64,
+    pub min_recent_volume: i64,
+    pub min_open_interest: i64,
+    pub min_dollar_volume: i64,
+    pub min_dollar_recent_volume: i64,
+    pub min_dollar_open_interest: i64,
+    pub min_liquidity: i64,
+    pub max_age_days: i64,
+    /// exclude question if community forecast puts a high probability on YES or NO
+    pub max_confidence: i64,
+    pub exclude_ids: HashSet<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -22,6 +22,7 @@ pub struct Kalshi {
 #[derive(Debug, Deserialize)]
 pub struct KalshiQuestionRequirements {
     pub require_open: bool,
+    pub page_size: i64,
     /// There are some events that use the same series ticker to group
     /// events. (Not to be confused with each event containing multiple
     /// markets for e.g. different price points of an asset.) For the most
@@ -44,7 +45,8 @@ pub struct KalshiQuestionRequirements {
     pub min_dollar_open_interest: i64,
     pub min_liquidity: i64,
     pub max_age_days: i64,
-    /// exclude question if community forecast puts a high probability on YES or NO
+    /// exclude question if yes_ask is too low or yes_bid is too high, such that
+    /// the probability of YES is too extreme to be interesting
     pub max_confidence: f64,
     pub exclude_ids: HashSet<String>,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -34,7 +34,7 @@ impl Question {
     pub fn embed_html(&self) -> Option<String> {
         match self.source {
             QuestionSource::Metaculus => {
-                Some(format!( 
+                Some(format!(
                     "<iframe src=\"https://www.metaculus.com/questions/question_embed/{}/?theme=dark\" \
                     style=\"height:430px; width:100%; max-width:550px\"></iframe>",
                     self.source_id


### PR DESCRIPTION
Add support for:
 - Manual and automatic mirroring of single Kalshi markets
 - auto-filtering based on Kalshi's provided market stats

Doesn't add support for:
- Kalshi events with multiple markets (multichoice). This rules out many, perhaps most kalshi markets :(
- Managrams support to mirror Kalshi markets

First project in Rust, all feedback and nitpicks appreciated!